### PR TITLE
Modify test function to build up object to get to the require function.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,5 +23,5 @@ function waitFor (thing, cb, i) {
 }
 
 function qubit () {
-  return window.__qubit
+  return window.__qubit && window.__qubit.amd && window.__qubit.amd.require
 }


### PR DESCRIPTION
For clients that deploy Opentag through their own tag manager, especially if it is deployed further down the page, then polling for the fully built up __qubit.amd.require object is necessary. An example would be Paragon Sports where the chrome extension script executes faster than smartserve causing a property of an undefined error.
@alanclarke 
