### PR TITLE
Make passing arguments to cb() be optional when firing it.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,9 @@ waitFor(qubit, run)
 
 function run () {
   require('script!global')
-  require('../qubit-loader!activation')({}, function (shouldActivate) {
-    if (!shouldActivate && shouldActivate !== undefined) {
+  require('../qubit-loader!activation')({}, function (pass) {
+    var shouldActivate = pass || typeof pass === 'undefined'
+    if (!shouldActivate) {
       console.log('activation returned false')
       return
     }


### PR DESCRIPTION
You can still pass arguments if you want, but it will allow activations to fire if you don't pass anything.
@alanclarke 
