### PR TITLE
scaffolding feature

### DIFF
--- a/bin/xp
+++ b/bin/xp
@@ -6,6 +6,7 @@ var pkg = require('../package.json')
 var createServer = require('../src/server')
 var getCerts = require('../src/server/lib/utils/https')
 var scaffold = require('../src/server/lib/code/scaffold')
+var read = require('../src/server/lib/code/read')
 var log = require('../src/server/lib/utils/log')
 
 program
@@ -13,6 +14,21 @@ program
   .description('open xp folder in finder, e.g. to locate chrome-extension')
   .action(function () {
     exec(`open ${path.dirname(__dirname)}`)
+  })
+
+program
+  .command('scaffold <template>')
+  .description('scaffold a project from a template')
+  .action(function templateScaffolding (template) {
+    exec(`npm link ${template}`, {
+      cwd: __dirname
+    }, (err) => {
+      if (err) return console.error(`could not find ${template} installed on your system`)
+      read(path.dirname(require.resolve(template)))
+        .then((codes) => {
+          return scaffold(process.cwd(), codes, true, log)
+        })
+    })
   })
 
 program

--- a/src/server/lib/code/read.js
+++ b/src/server/lib/code/read.js
@@ -11,12 +11,12 @@ module.exports = function readCode (dir) {
   ]
   return Promise.all(names.map(function (name) {
     var src = path.join(dir, addExtension(name))
-    return fs.readFile(src)
+    return fs.readFile(src).catch(() => false)
   }))
   .then(function (codes) {
     var result = {}
     var l = names.length
-    while (l--) result[names[l]] = String(codes[l])
+    while (l--) if (codes[l]) result[names[l]] = String(codes[l])
     return result
   })
 }

--- a/src/server/lib/code/scaffold.js
+++ b/src/server/lib/code/scaffold.js
@@ -13,12 +13,12 @@ module.exports = function scaffold (dest, codes, ask, log) {
       var file = path.join(dest, addExtension(name))
       var msg
       if (ask) {
-        msg = `Should ${chalk.green.bold('xp')} overwrite your local ${chalk.green.bold(name)} file with remote's?`
+        msg = `Do you want ${chalk.green.bold('xp')} to overwrite your local ${chalk.green.bold(name)} file?`
       }
       return shouldOverwrite(file, value, examples[name], msg)
         .then((result) => {
           if (result) {
-            if (log) log(`overwriting local ${chalk.green.bold(name)} file...`)
+            if (log) log(`writing to local ${chalk.green.bold(name)} file...`)
             return fs.writeFile(file, value)
           }
         })


### PR DESCRIPTION
This feature allows scaffolding projects from template modules

You can create a template module like so:

```
mkdir xp-template-name
cd xp-template-name
touch index.js
npm init
// create activation.js execution.js variation.css and global.js files
```

Then to consume it, first make it available globally:

```
// either
cd xp-template-name
npm link

// or if published to npm
npm install -g xp-template-name

// or if published to qubit registry
npm install -g @qubit/xp-template-name

// or if published to github, e.g. under qubtidigital
npm install -g qubitdigital/xp-template-name
```

now you can do this:

```
xp scaffold xp-template-name
```

and xp will scaffold your module from those template files

but crucially, you can have local scaffold projects for your own use, or you can publish and share them with teammates

@unknownbreaker @JakeRowsell89 
