### PR TITLE
Redefines remember preview module

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "less-loader": "^2.2.3",
     "lodash": "^4.16.0",
     "micro-amd": "^1.2.3",
+    "now-plus": "^1.0.3",
     "pem": "^1.8.3",
     "script-loader": "^0.7.0",
     "style-loader": "^0.13.1",

--- a/src/client/remember-preview.js
+++ b/src/client/remember-preview.js
@@ -1,11 +1,16 @@
-module.exports = function rememberPreview (minutes, additionalVariations, cookieDomain) {
+var cookie = require('cookieman')
+var now = require('now-plus')
+
+module.exports = function rememberPreview (minutes, additionalVariations, domain) {
   if (additionalVariations && additionalVariations.length) {
-    minutes = minutes || 15
     var variations = window.encodeURIComponent('[' + additionalVariations.join(',') + ']')
-    var date = new Date()
-    var domain = cookieDomain ? ' domain=' + cookieDomain + ';' : ''
-    date.setTime(date.getTime() + (minutes * 60 * 1000))
-    document.cookie = 'smartserve_preview=true; expires=' + date.toGMTString() + '; path=/;' + domain
-    document.cookie = 'etcForceCreative=' + variations + '; expires=' + date.toUTCString() + '; path=/;' + domain
+    var cookieOptions = {
+      expires: now.plus(minutes || 15, 'minutes'),
+      path: '/',
+      domain: domain
+    }
+
+    cookie.set('smartserve_preview', 'true', cookieOptions)
+    cookie.set('etcForceCreative', variations, cookieOptions)
   }
 }


### PR DESCRIPTION
Makes the remember preview module only drop preview cookies if additional variations are passed in. This is so that we can preview other experiences alongside the one we are developing in XP.

@citygent mind taking a look when you have a second? @alanclarke wouldn't really lift a finger to help so its all on you.
