### PR TITLE
Handle Virtual Pageviews

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -11,22 +11,25 @@ function init () {
   engine(opts, globalFn, triggerFn, variationFn)
   window.__qubit = window.__qubit || { smartserve: {} }
   window.__qubit.smartserve = window.__qubit.smartserve || {}
+  window.__qubit.xp = window.__qubit.xp || {}
+
   overrideStart(window.__qubit.smartserve, function () {
     return engine(opts, noop, triggerFn, variationFn)
   })
 }
 
 function overrideStart (smartserve, cb) {
-  var start
+  window.__qubit.xp.start = window.__qubit.xp.start || null
   Object.defineProperty(smartserve, 'start', {
+    configurable: true,
     get: function () {
       return function () {
         cb()
-        return start.apply(smartserve, arguments)
+        return window.__qubit.xp.start.apply(smartserve, arguments)
       }
     },
     set: function (newStart) {
-      start = newStart
+      window.__qubit.xp.start = newStart
     }
   })
 }


### PR DESCRIPTION
Safely (but disturbingly, even sadly) overwrites `window.__qubit.smartserve.start` so that the experience can be re-activated on a virtual pageview.

Again @citygent - your eyes would be appreciated. This is @alanclarke 's code really, so it may boggle you, as it did me. Give me a shout if you want me to explain what its doing.
