### PR TITLE
Hot reloading of triggers

### DIFF
--- a/src/client/engine.js
+++ b/src/client/engine.js
@@ -1,6 +1,6 @@
 module.exports = function experienceEngine (options, globalFn, triggerFn, variationFn) {
   globalFn()
-  if (triggerFn(options, activate)) execute()
+  if (triggerFn(options, activate) === true) execute()
 
   function activate (pass) {
     const shouldActivate = pass || typeof pass === 'undefined'

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -57,6 +57,7 @@ function handleHotReload (api) {
 function triggerFn (opts, cb) {
   var api = require('triggers')(opts, cb)
   handleHotReload(api)
+  return api
 }
 
 function variationFn (opts) {


### PR DESCRIPTION
Since we can now do this in the triggers in experiences...
```JS
return {
  remove: function () {}
}
```
... I have added code to allow for hot reloading when this api is returned.