### PR TITLE
fix diff and refactor

### DIFF
--- a/src/cmd/check-diff.js
+++ b/src/cmd/check-diff.js
@@ -28,15 +28,11 @@ module.exports = async function checkDiff (propertyId, experienceId) {
   function checkDiff (localFiles, files) {
     let diffs = []
     for (let name in files) {
-      if (files[name] && localFiles[name]) {
-        const value = files[name]
-        const localValue = localFiles[name]
-        const diff = value !== localValue
-
-        if (diff) { // If there is a diff then generate a diff output.
-          const diff = jsdiff.diffLines(value, localValue, [{ignoreWhitespace: true}])
-          diffs.push({fileName: name.toUpperCase(), diff: diff})
-        }
+      const remoteVal = files[name]
+      const localVal = localFiles[name]
+      if (remoteVal !== localVal) {
+        const diff = jsdiff.diffLines(remoteVal, localVal, [{ignoreWhitespace: true}])
+        diffs.push({fileName: name.toUpperCase(), diff: diff})
       }
     }
     return diffs


### PR DESCRIPTION
If one of the local or remote files were empty the diff wouldn't check. Could be an issue if someone adds code in css or global remotely, the changes would not show in xp diff. Refactored it too.