### PR TITLE
check both sets of files local and remote, catches deleted files

### DIFF
--- a/src/cmd/check-diff.js
+++ b/src/cmd/check-diff.js
@@ -25,6 +25,7 @@ module.exports = async function checkDiff (propertyId, experienceId) {
       const { fileName, diff, missingFile } = diffObj
       const msg = `${chalk.red.bold(`- This file does not exist ${missingFile}ly.`)}`
       console.log(`${chalk.blue.bold(fileName)} ${missingFile ? msg : ''}\n`)
+
       diff.forEach(parts => {
         let color = parts.added ? 'green' : parts.removed ? 'red' : 'grey'
         if (missingFile) {


### PR DESCRIPTION
- I've fixed the issue of potential null values being passed into the diff by setting the files to an empty string if they don't exist.
<img width="372" alt="screen shot 2017-03-03 at 15 55 33" src="https://cloud.githubusercontent.com/assets/7782211/23557978/dd0900b6-0029-11e7-817b-32a04be3f78e.png">


- I'm now running the diff across both sets of files and then making the array of diffs unique. This is more future proofing. It should catch cases where variations have been created locally or remotely and not for both versions.
<img width="335" alt="screen shot 2017-03-03 at 15 53 52" src="https://cloud.githubusercontent.com/assets/7782211/23557960/ce3c7e32-0029-11e7-9bd6-1b655132e0a6.png">
