### PR TITLE
Add functionality to create variations locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "qs": "^6.3.0",
     "raw-loader": "^0.5.1",
     "server-destroy": "^1.0.1",
+    "sillyname": "^0.1.0",
     "style-loader": "^0.13.2",
     "sync-p": "^1.1.3",
     "update-notifier": "^2.1.0",

--- a/src/cmd/duplicate.js
+++ b/src/cmd/duplicate.js
@@ -1,61 +1,33 @@
+const _ = require('lodash')
+const sillyname = require('sillyname')
 const log = require('../lib/log')
 const getPkg = require('../lib/get-pkg')
 const variationService = require('../services/variation')
-const readFiles = require('../lib/read-files')
-const chalk = require('chalk')
+const codeService = require('../services/code')
+const pickVariation = require('../lib/pick-variation')
+const scaffold = require('../lib/scaffold')
 const fs = require('fs-promise')
-const path = require('path')
-let CWD = process.cwd()
-const _ = require('lodash')
-const connect = require('../server/lib/connect')
-const template = require('./template')
-const down = require('../services/down')
 const mergePkg = require('../lib/merge-pkg')
+let CWD = process.cwd()
 
-module.exports = async function duplicate (variation) {
+module.exports = async function duplicate () {
   try {
-    const { EXECUTION, CSS } = variationService.DEFAULTS
     const pkg = await getPkg()
     const {propertyId, experienceId} = pkg.meta
-    const variationMatch = variation.match(/\d+/g)
-    const variationId = variationMatch && variationMatch[0]
-
-    const localFiles = await readFiles(CWD)
-    const executionCode = localFiles[`variation-${variationId}.js`]
-    const cssCode = localFiles[`variation-${variationId}.css`]
-
-    if (executionCode === undefined || cssCode === undefined) {
-    	return log(`${chalk.red.bold(`Duplication Failed: Variation ${variationId} does not exist.`)}`)
-    }
-
-    const variationData = {
-      advanced_mode: true,
-      custom_styles: cssCode || CSS,
-      execution_code: executionCode || EXECUTION,
-      experimentId: Number(experienceId),
-      isDirty: false,
-      name: `Variation ${variationId} copy`,
-      options: null
-    }
-
-    // const variationResponse = await variationService.duplicate(propertyId, experienceId, data)
-    // if (variationResponse) writeVariation(variationResponse)
-
-    // function writeVariation (variation) {
-    //   const variationJS = `variation-${variation.id}.js`
-    //   const variationCSS = `variation-${variation.id}.css`
-    //   if (variation.execution_code && variation.custom_styles) {
-    //     fs.outputFile(path.join(CWD, variationJS), variation.execution_code)
-    //     fs.outputFile(path.join(CWD, variationCSS), variation.custom_styles)
-    //   }
-    // }
-
-    const files = await down(propertyId, experienceId)
-    const val = files['package.json']
-    console.log(val)
-    if (_.get(pkg, 'meta')) mergePkg(pkg, files['package.json'])
-
-    // if (_.get(pkg, 'meta')) files['package.json'] = JSON.stringify(mergePkg(pkg, files['package.json']), null, 2)
+    const variations = pkg.meta.variations
+    const variationKey = pickVariation(Object.keys(variations).map(v => `${v}.js`)).replace('.js', '')
+    const variation = await variationService.get(propertyId, experienceId, variations[variationKey].variationId)
+    delete variation.id
+    delete variation.master_id
+    variation.name = `${sillyname().toLowerCase().replace(/[^\w]/gi, '-')}`
+    variation.execution_code = String(await fs.readFile(`${CWD}/${variationKey}.js`))
+    variation.custom_styles = String(await fs.readFile(`${CWD}/${variationKey}.css`))
+    const newVariation = await variationService.create(propertyId, experienceId, variation)
+    const fileName = variationService.getFilename(newVariation)
+    let files = _.pick(await codeService.get(propertyId, experienceId), ['package.json', `${fileName}.js`, `${fileName}.css`])
+    delete pkg.meta.variations[fileName]
+    if (_.get(pkg, 'meta')) files['package.json'] = JSON.stringify(mergePkg(pkg, files['package.json']), null, 2)
+    await scaffold(CWD, files, false, false)
   } catch (err) {
     log.error(err)
   }

--- a/src/cmd/index.js
+++ b/src/cmd/index.js
@@ -21,7 +21,7 @@ module.exports = function run (pkg) {
     .action(create)
 
   program
-    .command('duplicate <variation>')
+    .command('duplicate')
     .description('duplicate a variation')
     .action(duplicate)
 

--- a/src/lib/merge-pkg.js
+++ b/src/lib/merge-pkg.js
@@ -8,6 +8,7 @@ module.exports = function mergePkg (localPkg, remotePkg) {
   const pkg = Object.assign({}, localPkg, remotePkg)
   _.set(pkg, 'meta', _.merge({}, localPkg.meta, remotePkg.meta) || {})
   _.set(pkg, 'meta.templates', _.uniq(getTemplates(localPkg).concat(getTemplates(remotePkg))))
+  if (_.get(remotePkg, 'meta.variations')) pkg.meta.variations = remotePkg.meta.variations
   return pkg
 }
 

--- a/src/lib/pick-variation.js
+++ b/src/lib/pick-variation.js
@@ -1,4 +1,4 @@
-module.exports = async function pickVariation (names) {
-  names = names.filter(f => /\.js$/.test(f) && !/(triggers|global)/.test(f)).sort().reverse()
+module.exports = function pickVariation (names) {
+  names = names.filter(f => /\.js$/.test(f) && !/(triggers|global)/.test(f)).sort()
   return names[names.length - 1]
 }

--- a/src/services/variation.js
+++ b/src/services/variation.js
@@ -15,7 +15,7 @@ function set (propertyId, experienceId, variationId, val) {
   return fetch.put(getPath(propertyId, experienceId, variationId), { variation: val })
 }
 
-function duplicate (propertyId, experienceId, data) {
+function create (propertyId, experienceId, data) {
   return fetch.post(getPath(propertyId, experienceId), { variation: data })
 }
 
@@ -46,4 +46,4 @@ function getFilename (variation) {
   return `variation-${variation.master_id}`
 }
 
-module.exports = { getAll, get, set, duplicate, getCode, setCode, getFilename, DEFAULTS }
+module.exports = { getAll, get, set, create, getCode, setCode, getFilename, DEFAULTS }

--- a/test/test-pick-variation.js
+++ b/test/test-pick-variation.js
@@ -1,0 +1,8 @@
+const { expect } = require('chai')
+const pickVariation = require('../src/lib/pick-variation')
+
+describe('previewLink', function () {
+  it('should return the last one', function () {
+    expect(pickVariation(['1.js', '2.js'])).to.eql('2.js')
+  })
+})


### PR DESCRIPTION
- I've added a command ```xp duplicate``` which takes an argument of a variation ID and it will duplicate this locally and remotely along with the css and merge it into the package.json.

- I tab through my files to pass the argument to duplicate i.e. ```xp duplicate variation-12345.js```

 - I'm happy to change the command name, it's called duplicate on the platform so I went for that.

 - I'm also doing a bit of cleanup on the package.json after I merge the files. It will remove any variation objects from the p.j if those variations don't exist locally. Maybe this should be extracted and then it can be used on push or pull if necessary to synchronise the p.j's?