### PR TITLE
make `xp --watch` more friendly when it fails

### DIFF
--- a/src/server/lib/serve.js
+++ b/src/server/lib/serve.js
@@ -3,6 +3,7 @@ const webpackDevMiddleware = require('webpack-dev-middleware')
 const webpackHotMiddleware = require('webpack-hot-middleware')
 const webpack = require('webpack')
 const {readdir} = require('fs-promise')
+const chalk = require('chalk')
 const webpackConf = require('../../../webpack.conf')
 const push = require('../../cmd/push')
 const pickVariation = require('../../lib/pick-variation')
@@ -20,6 +21,12 @@ module.exports = async function serve (options) {
 
   if (!options.variation) {
     options.variation = await pickVariation(await readdir(CWD))
+
+    if (!options.variation) {
+      log(chalk.red('ensure you are within an experience directory and try again'))
+      return
+    }
+
     log(`using ${options.variation}`)
   }
 


### PR DESCRIPTION
I was trying to show xp to someone yesterday, and in my hurry to demonstrate the previewing functionality left myself in the wrong directory. The error I got was this:

![image](https://cloud.githubusercontent.com/assets/8490181/24143564/0d312664-0e22-11e7-8683-2e3542adb9cd.png)

It took me a minute or two to realise I wasn't in the right directory.

This PR solves that problem:

![image](https://cloud.githubusercontent.com/assets/8490181/24143594/2a0e6e7c-0e22-11e7-9847-31cfbc84a202.png)

Wasn't sure if this is the right place to handle the problem..