### PR TITLE
updated preview cookie logic

### DIFF
--- a/src/client/also.js
+++ b/src/client/also.js
@@ -5,12 +5,17 @@ let cm = require('cookieman')
 module.exports = function others (also, cookieDomain) {
   const cookieOptions = { path: '/', domain: cookieDomain, expires: now.plus(15, 'minutes') }
 
-  cm.set('smartserve_preview', 'true', cookieOptions)
   cm.clearAll('etcForceCreative')
+  cm.clearAll('smartserve_preview')
 
   if (also !== 'all') {
-    // force no other experiences to run
-    if (!also || !also.length) also = [-1]
+    if (also && also.length) {
+      // load ss preview if also parameter includes other experience ids
+      cm.set('smartserve_preview', 'true', cookieOptions)
+    } else {
+      // force no other experiences to run
+      also = [-1]
+    }
 
     // force other experiences to also run
     cm.set('etcForceCreative', encodeURIComponent('[' + also.join(',') + ']'), cookieOptions)

--- a/test/client/test-also.js
+++ b/test/client/test-also.js
@@ -20,8 +20,8 @@ describe('also', function () {
 
   describe('when called without any variations', function () {
     beforeEach(() => also(null, 'domain'))
-    it('should enable preview mode', function () {
-      expect(cm.set.calledWith('smartserve_preview', 'true')).to.eql(true)
+    it('should clear any preview cookies', function () {
+      expect(cm.clearAll.calledWith('smartserve_preview')).to.eql(true)
     })
     it('should clear any preexisting forceCreatives', function () {
       expect(cm.clearAll.calledWith('etcForceCreative')).to.eql(true)
@@ -30,10 +30,7 @@ describe('also', function () {
       expect(cm.set.calledWith('etcForceCreative', encodeURIComponent('[-1]'))).to.eql(true)
     })
     it('should force a creative that does not exist', function () {
-      expect(db).to.eql({
-        etcForceCreative: '[-1]',
-        smartserve_preview: 'true'
-      })
+      expect(db).to.eql({ etcForceCreative: '[-1]' })
     })
   })
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/5023972/24438355/dd3efe06-1414-11e7-8260-07ad60f2421c.png)
- Error above related to the fact that smartserve-preview script was loading on the page and looking for a valid variationMasterId (see logic [here](https://github.com/qubitdigital/experience-engine/blob/4e495b9d20b5a717f8cf41c72912ea4e72c7d463/lib/etc.js#L51))
- Prior default behavior was setting the `smartserve_preview` and thus causing the error to  be thrown since -1 would never yield a valid experiment ID
- In reality, only the `etcForceCreative` cookie is required to gain the desired outcome of suppressing live experiences
- This update only sets the `smartserve_preview` cookie in the event that the `also` parameter is populated as an array with at least value (presumably a valid `variationMasterId`)