### PR TITLE
stop lodash going onto the window scope

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,6 +1,6 @@
 /* globals __VARIATION__ __CWD__ */
 const context = require.context(__CWD__)
-const _ = require('lodash')
+const _ = require('lodash').noConflict()
 const Promise = require('sync-p/extra')
 const engine = require('./engine')
 const also = require('./also')


### PR DESCRIPTION
lodash was getting exposed on the window scope and causing issue on clients that have underscore/lodash already on the window scope