### PR TITLE
Experiences are created with the correct execution code

### DIFF
--- a/src/services/experience.json
+++ b/src/services/experience.json
@@ -4,7 +4,10 @@
   "editor_version": 3,
   "recent_iterations": {
     "draft": {
-      "variations": [{ "advanced_mode": 1 }]
+      "variations": [{
+        "advanced_mode": 1,
+        "execution_code": "function execution (options) { // eslint-disable-line no-unused-vars\n\n}"
+      }]
     }
   },
   "solution_id": 6


### PR DESCRIPTION
Original code was creating experiences where the execution code was...
```JS
function (options) {}
```
This is now fixed to produce...
```JS
function execution (options) { // eslint-disable-line no-unused-vars

}
```