### PR TITLE
Fix buble transforms settings

### DIFF
--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -32,7 +32,7 @@ module.exports = {
       { test: /\.js$/, include: [path.join(__dirname, 'node_modules', '@qubit')], loader: 'legacy-css' },
       { test: /\.css$/, include: [path.join(__dirname, 'node_modules', '@qubit')], loader: 'style-loader!raw-loader!less-loader' },
       { test: /global\.js$/, loader: 'raw-loader' },
-      { test: /\.js$/, include: [cwd], exclude: [/global\.js/], loader: '@qubit/xp-loader!buble-loader?objectAssign=Object.assign,dangerousForOf=true,dangerousTaggedTemplateString=true' },
+      { test: /\.js$/, include: [cwd], exclude: [/global\.js/], loader: '@qubit/xp-loader!buble-loader?{"objectAssign": "Object.assign", "transforms": { "dangerousForOf": true, "dangerousTaggedTemplateString": true } }' },
       { test: /\.css$/, loader: 'raw-loader!less-loader', exclude: [path.join(__dirname, 'node_modules')] },
       { test: /\.json$/, loader: 'json-loader' }
     ]


### PR DESCRIPTION
Fix to enable buble's "dangerous transforms" as I pulled a published experience from the platform and encountered the following error trying to use xp:

```
$ xp --watch -v
2017-08-30 15:00:00:  using variation-537823.js
2017-08-30 15:00:00:  xp listening on port 41337
2017-08-30 15:00:03:  webpack built 0b08b3460f2bbd82e62b in 3307ms
Hash: 0b08b3460f2bbd82e62b
Time: 3307ms
chunk    {0} bundle.js, bundle.js.map (main) 1.35 MB [entry] [rendered]

ERROR in ./variation-537823.js
Module build failed:
1 : function execution (options) { // eslint-disable-line no-unused-vars
2 :   const { $container, trendingTours, currency } = options.state.get('data')
3 :
4 :   const tourHtml = ({ name, price, days, imgUrl, url }) =>
5 :     htmlTemplate`
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Tagged template strings are not supported. Use `transforms: { templateString: false }` to skip transformation and disable this error, or `transforms: { dangerousTaggedTemplateString: true }` if you know what you're doing (5:4)
Error
    at handleError (/Users/samuelrowe/.nvm/versions/node/v8.1.2/lib/node_modules/@qubit/xp-cli/node_modules/buble-loader/index.js:22:15)
    at Object.BubleLoader (/Users/samuelrowe/.nvm/versions/node/v8.1.2/lib/node_modules/@qubit/xp-cli/node_modules/buble-loader/index.js:38:9)
 @ /Users/samuelrowe/.nvm/versions/node/v8.1.2/lib/~/@qubit/xp-cli/src/client/index.js 23:15-37
 @ multi /Users/samuelrowe/.nvm/versions/node/v8.1.2/lib/~/@qubit/xp-cli/src/client/index webpack-hot-middleware/client?path=https://localhost:41337/__webpack_hmr&timeout=20000&reload=true&&noInfo=true&&quiet=true
2017-08-30 15:00:04:  webpack: Failed to compile.
2017-08-30 15:00:41:  webpack: Compiling...
2017-08-30 15:00:42:  webpack building...
```