### PR TITLE
Refresh token if npmrc has been deleted

### DIFF
--- a/src/lib/qubitrc.js
+++ b/src/lib/qubitrc.js
@@ -1,5 +1,6 @@
 const _ = require('lodash')
 const yaml = require('js-yaml')
+const log = require('./log')
 const fs = require('fs-extra')
 let { QUBITRC } = require('./constants')
 let inMemory = false
@@ -34,6 +35,7 @@ function get (key) {
 async function set (key, value) {
   return read().then(currentData => {
     let env = getEnv()
+    log.debug(`setting ${env}:${key} in to ${value}`)
     currentData[env] = currentData[env] || {}
     Object.assign(currentData[env], { [key]: value })
     return write(currentData)


### PR DESCRIPTION
@KidkArolis turns out qubit-cli already checks if the token has expired - `qubit login` should have refreshed the token. Either we're not checking the expiry correctly or there's another reason why enporium rejected it. It would be helpful to get the token if it happens again, I would like to investigate. Either way, qubit-cli will reconfigure npmrc if the file is deleted after this pr