### PR TITLE
Adds default behavior to link command

### DIFF
--- a/src/cmd/link.js
+++ b/src/cmd/link.js
@@ -14,8 +14,8 @@ module.exports = async function links (page, options) {
 
     const experienceUrl = `https://app.qubit.com/p/${propertyId}/experiences/${experienceId}`
 
-    if (/^editor|settings|overview$/.test(page)) {
-      return link(`${experienceUrl}/${page === 'overview' ? '' : page}`)
+    if (/^editor|settings$/.test(page)) {
+      return link(`${experienceUrl}/${page}`)
     }
 
     if (page === 'preview') {
@@ -23,6 +23,8 @@ module.exports = async function links (page, options) {
       const links = await getPreviewLinks(pkg.meta)
       link(links.join('\n'))
     }
+
+    return link(experienceUrl)
   } catch (err) {
     log.error(err)
   }


### PR DESCRIPTION
Currently, running `qubit link` on its own doesn't do anything.

Instead of requiring the user to specify `qubit link overview`, logging and copying the overview link is now the default behavior of `qubit link`.