### PR TITLE
Better login

### DIFF
--- a/src/cmd/login.js
+++ b/src/cmd/login.js
@@ -1,8 +1,10 @@
 const login = require('../server/lib/login')
+const qubitrc = require('../lib/qubitrc')
 const log = require('../lib/log')
 
 module.exports = async function loginCmd (id) {
   try {
+    await qubitrc.logout()
     await login()
     log.info('Login successful!')
   } catch (err) {


### PR DESCRIPTION
Atm, manually running the qubit login command doesn't do anything if you are already logged in. This lazy behaviour is cool when added as middleware for other commands but I think when the user explicitly requests a login a better behaviour is to reset the login credentials and scopes.