### PR TITLE
Avoid require.context

### DIFF
--- a/loaders/entry.js
+++ b/loaders/entry.js
@@ -1,0 +1,16 @@
+const path = require('path')
+const fs = require('fs-extra')
+const CWD = process.cwd()
+
+module.exports = function loader (content, { file }) {
+  let callback = this.async()
+  getFiles().then(files => {
+    content = content.replace(/.+\*\//, '')
+    content = content.replace('__FILES__', `[${files.join(',')}]`)
+    callback(null, content)
+  })
+}
+
+async function getFiles () {
+  return (await fs.readdir(CWD)).filter(f => /\.(js|css|json)$/.test(f)).map(f => `require.resolve('${path.join(CWD, f)}')`)
+}

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,6 +1,4 @@
-/* globals __VARIATION__ __CWD__ */
-const context = require.context(__CWD__, false)
-const _ = require('slapdash')
+/* globals __VARIATION__ __FILES__ */
 const Promise = require('sync-p/extra')
 const engine = require('./engine')
 const also = require('./also')
@@ -10,7 +8,7 @@ const onSecondPageView = require('./pageview')
 const redirectTo = require('./redirect-to')
 const applyStyles = require('./styles')
 const globalFn = once(() => eval.call(window, require('global'))) // eslint-disable-line
-const STYLE_ID = 'qubit-xp-styles'
+const STYLE_ID = 'qubit-cli-styles'
 
 require('./amd')()
 let {destroy, modules, variationIsSpent, triggersIsSpent, hasActivated, runAcrossViews} = init()
@@ -109,7 +107,7 @@ function restart (bypassTriggers) {
 
 function registerHotReloads (restart) {
   if (!module.hot) return
-  module.hot.accept(allModules(), () => {
+  module.hot.accept(__FILES__, () => {
     const newModules = loadModules()
     const edited = Object.keys(newModules).find(m => newModules[m] !== modules[m])
     modules = newModules
@@ -123,10 +121,6 @@ function registerHotReloads (restart) {
     if (hasActivated()) restart(true)
     // if hasn't activated yet no need to restart, as variation is loaded dynamically
   })
-
-  function allModules () {
-    return _.unique(context.keys().map(key => context.resolve(key))).concat([require.resolve(__VARIATION__ + '.js')])
-  }
 }
 
 function once (fn) {

--- a/src/client/log.js
+++ b/src/client/log.js
@@ -1,3 +1,3 @@
-const createLogger = require('driftwood')
-createLogger.enable({ '*': 'trace' })
-module.exports = createLogger('Qubit-CLI')
+const logger = require('driftwood')('Qubit-CLI')
+logger.enable({ '*': 'trace' })
+module.exports = logger

--- a/src/server/lib/serve.js
+++ b/src/server/lib/serve.js
@@ -77,7 +77,6 @@ module.exports = async function serve (options) {
 function createWebpackConfig (options) {
   const plugins = webpackConf.plugins.slice(0)
   plugins.push(new webpack.DefinePlugin({
-    __CWD__: `'${CWD}'`,
     __VARIATION__: `'${options.variationFilename}'`
   }))
   const entry = webpackConf.entry.slice(0)

--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -34,6 +34,7 @@ module.exports = {
       { test: /\.js$/, include: [path.join(__dirname, 'node_modules', '@qubit')], loader: 'experience-css' },
       { test: /\.css$/, include: [path.join(__dirname, 'node_modules', '@qubit')], loader: 'style-loader!raw-loader!less-loader' },
       { test: /global\.js$/, loader: 'raw-loader' },
+      { test: /index\.js$/, include: [path.join(__dirname, 'src/client')], loader: 'entry!buble-loader?{"objectAssign": "Object.assign", "transforms": { "dangerousForOf": true, "dangerousTaggedTemplateString": true } }' },
       { test: /\.js$/, include: [cwd], exclude: [/global\.js/, /node_modules/], loader: 'experience-js!buble-loader?{"objectAssign": "Object.assign", "transforms": { "dangerousForOf": true, "dangerousTaggedTemplateString": true } }' },
       { test: /\.css$/, loader: 'raw-loader!less-loader', exclude: [path.join(__dirname, 'node_modules')] },
       { test: /\.json$/, loader: 'json-loader' }


### PR DESCRIPTION
require.context seems to not work as well on windows so am trying an alternative approach, which uses a loader to rewrite __FILES__ before webpack's resolver runs

![screen shot 2018-02-07 at 16 25 23](https://user-images.githubusercontent.com/640611/35927812-8a7297a2-0c23-11e8-92df-872045cd35b9.png)
