### PR TITLE
Remove global.js for experiences that don't have it

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -6,7 +6,7 @@ const evaluateVariation = require('./evaluate-variation')
 const createOptions = require('./options')
 const onSecondPageView = require('./pageview')
 const applyStyles = require('./styles')
-const globalFn = once(() => eval.call(window, require('global'))) // eslint-disable-line
+const globalFn = once(evalGlobal)
 const STYLE_ID = 'qubit-cli-styles'
 require('./amd')()
 
@@ -46,7 +46,7 @@ function loadModules () {
     pkg: require('package.json'),
     variation: require(__VARIATION__),
     styles: require(__VARIATION__ + __VARIATION_STYLE_EXTENSION__),
-    global: require('global'),
+    global: requireGlobal(),
     triggers: require('triggers')
   }
 }
@@ -153,4 +153,18 @@ function once (fn) {
     called = true
     fn()
   }
+}
+
+function requireGlobal () {
+  try {
+    return require('global')
+  } catch (err) {
+    return ''
+  }
+}
+
+function evalGlobal () {
+  try {
+    eval.call(window, requireGlobal()) // eslint-disable-line
+  } catch (err) {}
 }

--- a/src/cmd/push.js
+++ b/src/cmd/push.js
@@ -4,6 +4,7 @@ const log = require('../lib/log')
 const getPkg = require('../lib/get-pkg')
 const updatePkg = require('../lib/update-pkg')
 const readFiles = require('../lib/read-files')
+const globalCodeWarning = require('../lib/global-code-warning')
 const commonCodeWarning = require('../lib/common-code-warning')
 const cssCodeWarning = require('../lib/css-code-warning')
 const codeService = require('../services/code')
@@ -19,6 +20,7 @@ module.exports = async function push (options = {}) {
   const { propertyId, experienceId } = (pkg.meta || {})
   if (!propertyId || !experienceId) return log.info('Nothing to push')
 
+  await globalCodeWarning(CWD)
   await commonCodeWarning(CWD)
   await cssCodeWarning(CWD)
 

--- a/src/lib/global-code-warning.js
+++ b/src/lib/global-code-warning.js
@@ -1,0 +1,11 @@
+const path = require('path')
+const fs = require('fs-extra')
+// const log = require('./log')
+
+// This is a placeholder for when pre script is released
+module.exports = async function renameFileWarning (dest) {
+  const exists = await fs.pathExists(path.join(dest, 'global.js'))
+  if (exists) {
+    // log.warn(`global.js is being deprecated in favour of better solutions such as packages and pre-script`)
+  }
+}

--- a/src/lib/pick-variation.js
+++ b/src/lib/pick-variation.js
@@ -1,4 +1,7 @@
+const _ = require('lodash')
+
 module.exports = function pickVariation (names) {
-  names = names.filter(f => /\.js$/.test(f) && !/(triggers|global)/.test(f)).sort()
-  return names[names.length - 1]
+  return _.last(names
+    .filter(f => /\.js$/.test(f) && f.includes('variation'))
+    .sort())
 }

--- a/src/lib/pull-experience.js
+++ b/src/lib/pull-experience.js
@@ -1,15 +1,15 @@
 const down = require('../services/down')
 const scaffold = require('./scaffold')
 const log = require('./log')
+const globalCodeWarning = require('../lib/global-code-warning')
 const commonCodeWarning = require('../lib/common-code-warning')
 const cssCodeWarning = require('../lib/css-code-warning')
 
 module.exports = async function pullExperience (CWD, propertyId, experienceId, iterationId) {
   const { files, experience } = await down(experienceId, iterationId)
   log.info(`Pulling experience ${experienceId}: ${experience.name}`)
-  if (experience.solution_id === 7) {
-    throw new Error('qubit-cli does not support simple message experiences')
-  }
+
+  await globalCodeWarning(CWD)
   await commonCodeWarning(CWD)
   await cssCodeWarning(CWD)
 

--- a/src/server/lib/serve.js
+++ b/src/server/lib/serve.js
@@ -8,6 +8,7 @@ const webpackConf = require('../../../webpack.conf')
 const config = require('../../../config')
 const log = require('../../lib/log')
 const createApp = require('../app')
+const globalCodeWarning = require('../../lib/global-code-warning')
 const commonCodeWarning = require('../../lib/common-code-warning')
 const cssCodeWarning = require('../../lib/css-code-warning')
 const installQubitDeps = require('../../lib/install-qubit-deps')
@@ -26,6 +27,7 @@ module.exports = async function serve (options) {
     log.info('Hint: you should be watching the entry point for your experience, i.e. your variation file!')
   }
 
+  await globalCodeWarning(CWD)
   await commonCodeWarning(CWD)
   await cssCodeWarning(CWD)
 

--- a/src/services/iteration.js
+++ b/src/services/iteration.js
@@ -33,22 +33,29 @@ function getCode (iteration) {
   const commonCode = iteration.common_code
   const schema = JSON.stringify(iteration.schema, null, 2)
 
-  return {
-    'global.js': hasNoCode(globalCode) ? GLOBAL_CODE : globalCode,
+  const code = {
     'triggers.js': hasNoCode(triggers) ? TRIGGERS : triggers,
     'fields.json': hasNoCode(schema) ? SCHEMA : schema,
     'utils.js': hasNoCode(commonCode) ? COMMON_CODE : commonCode
   }
+
+  if (!hasNoCode(globalCode)) code['global.js'] = globalCode
+
+  return code
 }
 
 function setCode (iteration, files) {
-  return {
+  const code = {
     ...iteration,
     global_code: hasNoCode(files['global.js']) ? GLOBAL_CODE : files['global.js'],
     common_code: hasNoCode(files['utils.js']) ? COMMON_CODE : files['utils.js'],
     schema: JSON.parse(hasNoCode(files['fields.json']) ? SCHEMA : files['fields.json']),
     triggers: hasNoCode(files['triggers.js']) ? TRIGGERS : files['triggers.js']
   }
+
+  if (!hasNoCode(files['global.js'])) code.global_code = files['global.js']
+
+  return code
 }
 
 module.exports = { get, set, getAll, getCode, setCode }

--- a/test/test-pick-variation.js
+++ b/test/test-pick-variation.js
@@ -3,6 +3,6 @@ const pickVariation = require('../src/lib/pick-variation')
 
 describe('previewLink', function () {
   it('should return the last one', function () {
-    expect(pickVariation(['1.js', '2.js'])).to.eql('2.js')
+    expect(pickVariation(['variation-1.js', 'variation-2.js'])).to.eql('variation-2.js')
   })
 })


### PR DESCRIPTION
After this PR:

- qubit cli will not create a `global.js` file for experiences with no `global.js` code
- on pull, if the users' local `global.js` file is empty it will ask the user if they would like qubit cli to remove their local `global.js` file
