### PR TITLE
Create cmd params

### DIFF
--- a/src/cmd/create.js
+++ b/src/cmd/create.js
@@ -7,13 +7,13 @@ const CWD = process.cwd()
 const { getPropertyId } = require('../lib/get-resource-ids')
 const { getPublishedTemplates } = require('../lib/get-templates')
 
-module.exports = async function create (pid, xpName, traffic) {
+module.exports = async function create (pid, xpName, traffic, selectedTemplate = null) {
   const propertyId = await getPropertyId(pid)
 
+  const isProgrammatic = pid && xpName && traffic && !selectedTemplate
   const templates = await getPublishedTemplates(propertyId)
-  let selectedTemplate = null
 
-  if (templates.length) {
+  if (templates.length && !isProgrammatic) {
     selectedTemplate = await input.select(
       formatLog(`   Please select a template you'd like to create this experience from:`),
       formatTemplates(templates),

--- a/src/cmd/create.js
+++ b/src/cmd/create.js
@@ -7,26 +7,28 @@ const CWD = process.cwd()
 const { getPropertyId } = require('../lib/get-resource-ids')
 const { getPublishedTemplates } = require('../lib/get-templates')
 
-module.exports = async function create (pid, xpName, traffic, selectedTemplate = null) {
+module.exports = async function create (pid, name, traffic, templateId = null) {
   const propertyId = await getPropertyId(pid)
 
-  const isProgrammatic = pid && xpName && traffic && !selectedTemplate
+  const isProgrammatic = pid && name && traffic && !templateId
   const templates = await getPublishedTemplates(propertyId)
 
   if (templates.length && !isProgrammatic) {
-    selectedTemplate = await input.select(
+    templateId = await input.select(
       formatLog(`   Please select a template you'd like to create this experience from:`),
       formatTemplates(templates),
       { default: null }
     )
   }
 
-  const name = xpName || clean(await input.text(
-    formatLog('   What would you like to call your experience?'),
-    { default: 'Created by Qubit-CLI' }
-  ))
+  if (!name) {
+    name = clean(await input.text(
+      formatLog('   What would you like to call your experience?'),
+      { default: 'Created by Qubit-CLI' }
+    ))
+  }
   const controlDecimal = traffic || await input.select(formatLog('   Select control size'), validControlSizes, { default: 0.5 })
-  await createExperience(CWD, propertyId, name, controlDecimal, selectedTemplate)
+  await createExperience(CWD, propertyId, name, controlDecimal, templateId)
 }
 
 function clean (str) {

--- a/src/cmd/create.js
+++ b/src/cmd/create.js
@@ -7,7 +7,7 @@ const CWD = process.cwd()
 const { getPropertyId } = require('../lib/get-resource-ids')
 const { getPublishedTemplates } = require('../lib/get-templates')
 
-module.exports = async function create (pid) {
+module.exports = async function create (pid, xpName, traffic) {
   const propertyId = await getPropertyId(pid)
 
   const templates = await getPublishedTemplates(propertyId)
@@ -21,11 +21,11 @@ module.exports = async function create (pid) {
     )
   }
 
-  const name = clean(await input.text(
+  const name = xpName || clean(await input.text(
     formatLog('   What would you like to call your experience?'),
     { default: 'Created by Qubit-CLI' }
   ))
-  const controlDecimal = await input.select(formatLog('   Select control size'), validControlSizes, { default: 0.5 })
+  const controlDecimal = traffic || await input.select(formatLog('   Select control size'), validControlSizes, { default: 0.5 })
   await createExperience(CWD, propertyId, name, controlDecimal, selectedTemplate)
 }
 

--- a/src/cmd/index.js
+++ b/src/cmd/index.js
@@ -72,7 +72,7 @@ module.exports = async function run (pkg) {
     Create using propertyId:
     qubit create 1010
 
-    Crete using propertyId and new experience name:
+    Create using propertyId and new experience name:
     qubit create 1010 myExperiece
 
     Create using propertyId and new experience name and traffic split:

--- a/src/cmd/index.js
+++ b/src/cmd/index.js
@@ -67,10 +67,16 @@ module.exports = async function run (pkg) {
     })
 
   program
-    .command('create [propertyId]')
+    .command('create [propertyId] [name] [split]')
     .usage(chalk.gray(`
     Create using propertyId:
     qubit create 1010
+
+    Crete using propertyId and new experience name:
+    qubit create 1010 myExperiece
+
+    Create using propertyId and new experience name and traffic split:
+    qubit create 1010 myExperiece 0.5
 
     Create using autocomplete or by navigating to your experience in the browser:
     qubit clone`))

--- a/src/cmd/index.js
+++ b/src/cmd/index.js
@@ -67,7 +67,7 @@ module.exports = async function run (pkg) {
     })
 
   program
-    .command('create [propertyId] [name] [split]')
+    .command('create [propertyId] [name] [split] [template]')
     .usage(chalk.gray(`
     Create using propertyId:
     qubit create 1010


### PR DESCRIPTION
Add ability to pass in parameters through CLI for `create` command.
Params are:
`qubit create [pid] [experienceName] [trafficSplit] [templateId]`
Example:
`qubit create 1010 myExperience 0.5 196961`

If [pid] [experienceName] [trafficSplit] are provided but [templateId] isn't it will default to null without prompt