### PR TITLE
Fix/placement styling

### DIFF
--- a/src/client/serve-placement.js
+++ b/src/client/serve-placement.js
@@ -9,12 +9,15 @@ const getCookieDomain = require('./get-cookie-domain')
 const applyPreviewSettings = require('./preview-settings')
 const disposables = []
 const { VIEW_REGEX } = require('@qubit/placement-engine/lib/constants')
+
+const PLACEMENT_STYLE_ELEMENT_ID = 'qubit-cli-placement-styles'
+
 let disposeViewListener = () => {}
 
 servePlacement()
 
 module.hot.accept(['placement.less'], () => {
-  const styleElement = document.getElementById('qubit-cli-placement-styles')
+  const styleElement = document.getElementById(PLACEMENT_STYLE_ELEMENT_ID)
   if (styleElement) {
     styleElement.innerHTML = require('placement.less')
   }
@@ -60,7 +63,7 @@ function servePlacement () {
       let remove
       const add = () => {
         remove = applyStyles(
-          'qubit-cli-placement-styles',
+          PLACEMENT_STYLE_ELEMENT_ID,
           require('placement.less')
         )
       }

--- a/src/client/serve-placement.js
+++ b/src/client/serve-placement.js
@@ -14,7 +14,10 @@ let disposeViewListener = () => {}
 servePlacement()
 
 module.hot.accept(['placement.less'], () => {
-  applyStyles('qubit-cli-placement-styles', require('placement.less'))
+  const styleElement = document.getElementById('qubit-cli-placement-styles')
+  if (styleElement) {
+    styleElement.innerHTML = require('placement.less')
+  }
 })
 
 module.hot.accept(
@@ -112,10 +115,7 @@ function servePlacement () {
     const pass = evaluateTriggers(code.triggers, api, context)
     if (!pass) return
 
-    return createExecutioner(
-      code,
-      api
-    )({
+    return createExecutioner(code, api)({
       content: payload,
       onImpression: () => api.log.info('onImpression called'),
       onClickthrough: () => api.log.info('onClickthrough called')

--- a/webpack.js
+++ b/webpack.js
@@ -56,7 +56,6 @@ module.exports = function createWebpackConfig () {
         {
           test: /\.(css|less)$/,
           use: [
-            'style-loader',
             'raw-loader',
             {
               loader: 'experience-less',


### PR DESCRIPTION
### Description

**Issue**

`styles.add()` and `styles.remove()` would have no impact because when the placement was served two `<style>` elements were created one with an id `qubit-cli-placement-styles` and the content `[Object object]` and another anonymous `<style>` element with the placement css, thus being unable to add or remove styles.

**Fix**

Ensured the CSS loader only transformed `.less` files and returned the string, rather than bundling code to automatically append head with an anonymous `<style>` element

While I was here I also made sure the hot reloader only reapplied styles if `styles.remove()` had not removed the `<style id="qubit-cli-placement-styles">` element
