### PR TITLE
Allow webpack to use module resolution defaults

### DIFF
--- a/webpack.js
+++ b/webpack.js
@@ -32,7 +32,6 @@ module.exports = function createWebpackConfig () {
         path.join(CWD, 'node_modules'),
         path.join(__dirname, 'node_modules')
       ],
-      mainFields: ['browser', 'main'],
       alias: { jquery: '@qubit/jquery' }
     },
     resolveLoader: {


### PR DESCRIPTION
Bring the webpack module type resolution into line with that used by SSG. SSG doesn't specify module type resolution, instead it uses Webpack defaults. In this case the defaults are broswers, module, main (package.json keys) 