### PR TITLE
document_npm_install_version_constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,14 @@ _Automate your workflow by interacting with the platform from the command line:_
 
 ## Installation
 
-`npm install -g qubit-cli`
+On Wed 8 Sept 2021, we identified that the CLI must be install with npm =< v7.20.2 for `qubit` command to function properly
+
+```
+npm install -g npm@7.20.2
+npm install -g qubit-cli
+```
+
+once install you are free to use the latest version of npm `npm install -g npm@latest`
 
 ## Windows
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "1.74.0",
+      "version": "1.74.1",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.21.1",


### PR DESCRIPTION
Discovered that a change introduced in npm v7.20.3 causes qubit-cli to install incorrectly. Installation appears to go fine without error, however when running qubit command throws an error. The error seems unrelated - unable to resolve @qubit/buble-loader. This PR adds documentation of this contraint whilst a longer term fix can be found