### PR TITLE
Fix passthrough of selected property ID when cloning/pulling placements

### DIFF
--- a/src/cmd/placement/clone.js
+++ b/src/cmd/placement/clone.js
@@ -18,7 +18,7 @@ module.exports = async function clone (
   isOneOf(implementationType)
   const pkg = await getPkg()
   const propertyId = await getPropertyId(propertyIdOrUrl, pkg)
-  placementId = await getPlacementId(propertyIdOrUrl, placementId, pkg)
+  placementId = await getPlacementId(propertyIdOrUrl || propertyId, placementId, pkg)
   const files = await placementService.addHelpers(
     await placementService.get(propertyId, placementId)
   )

--- a/src/cmd/placement/pull.js
+++ b/src/cmd/placement/pull.js
@@ -17,7 +17,7 @@ module.exports = async function pull (
   isOneOf(implementationType)
   const pkg = await getPkg()
   const propertyId = await getPropertyId(propertyIdOrUrl, pkg)
-  placementId = await getPlacementId(propertyIdOrUrl, placementId, pkg)
+  placementId = await getPlacementId(propertyIdOrUrl || propertyId, placementId, pkg)
   const files = await placementService.get(
     propertyId,
     placementId,


### PR DESCRIPTION
Currently, if you do `qubit placement clone` without providing the URL to a placement, you get this error:

![Screenshot 2021-09-14 at 12 35 49](https://user-images.githubusercontent.com/621323/133250595-af189b4e-e9a5-40ea-ac59-433649b2f2df.png)

It happens because `propertyIdOrUrl` is undefined, meaning we are passing through no usable information to `getPlacementId` in order to suggest a placement. The fix here is to fall back to the propertyId that was selected on the previous line. 