### PR TITLE
Append experience styles before modules as in prod

### DIFF
--- a/src/client/styles.js
+++ b/src/client/styles.js
@@ -1,7 +1,15 @@
 module.exports = function applyStyles (id, styles) {
   const el = document.getElementById(id) || document.createElement('style')
   el.id = id
-  document.head.appendChild(el)
+
+  // Keep alignment with experiences which appends styles first before module styles
+  const styleTags = document.getElementsByTagName('style')
+  if (styleTags && styleTags[0].parentElement.nodeName === 'HEAD') {
+    document.head.insertBefore(el, styleTags[0])
+  } else {
+    document.head.appendChild(el)
+  }
+
   el.innerHTML = styles
   return () => {
     const el = document.getElementById(id)


### PR DESCRIPTION
I found it confusing that styles works differently for experiences on the platform. The experiences-engine intentionally appends an experiences styles first before those of its module requires. This brings qubit-cli into alignment. https://github.com/qubitdigital/experience-engine/blob/master/lib/executions/advanced.js#L19