### PR TITLE
Fix: Guard against case where no style tags are found

### DIFF
--- a/src/client/styles.js
+++ b/src/client/styles.js
@@ -4,7 +4,7 @@ module.exports = function applyStyles (id, styles) {
 
   // Keep alignment with experiences which appends styles first before module styles
   const styleTags = document.getElementsByTagName('style')
-  if (styleTags && styleTags[0].parentElement.nodeName === 'HEAD') {
+  if (styleTags && styleTags.length && styleTags[0].parentElement.nodeName === 'HEAD') {
     document.head.insertBefore(el, styleTags[0])
   } else {
     document.head.appendChild(el)


### PR DESCRIPTION
Fix to cover cases where `src/client/styles` does not find existing style tags on the page.